### PR TITLE
Quick fix. Error Cannot redeclare function

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -559,16 +559,6 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
   /**
    * @inheritDoc
    */
-  public function isPasswordUserGenerated() {
-    if (\Drupal::config('user.settings')->get('verify_mail') == TRUE) {
-      return FALSE;
-    }
-    return TRUE;
-  }
-
-  /**
-   * @inheritDoc
-   */
   public function updateCategories() {
     // @todo Is anything necessary?
   }


### PR DESCRIPTION
Overview
----------------------------------------
When trying to install CiviCRM module on Drupal 8.x an error of type _Cannot redeclare function_ is trhowed and site becomes unfunctional. Even drush can't make any operation.
